### PR TITLE
Add Day1 setup automation script and update docs

### DIFF
--- a/Agents.MD
+++ b/Agents.MD
@@ -351,6 +351,11 @@ Before starting work on any component:
 - [ ] Update this `Agents.MD` with your contribution area
 - [ ] Begin implementation with frequent commits and documentation updates
 
+## Recent Contributions
+- Added `scripts/day1_setup.sh` for DevOps automation of initial environment tasks.
+- Updated `SprintPlan.MD` with notes about the script.
+- Expanded `README.md` with quick-start instructions.
+
 ## Emergency Contacts and Escalation
 
 If you encounter critical issues or need architectural decisions:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # LLM-RAG-OS: Hybrid Semantic Operating System
+
+This repository hosts early research and prototyping work for an operating system that leverages Large Language Models (LLMs) with Retrieval-Augmented Generation (RAG). The project is in the **Foundation & Research** phase as documented in `Agents.MD`.
+
+## Quick Start
+
+A helper script is provided to automate the initial environment setup and kernel build steps described in `day1.MD`.
+
+```bash
+./scripts/day1_setup.sh
+```
+
+The script installs basic build dependencies, clones the kernel source, compiles it, and performs a QEMU boot test. Many steps require sudo privileges and sufficient hardware resources.
+
+See `SprintPlan.MD` for sprint goals and `ImplimentationGuide.MD` for design details.

--- a/SprintPlan.MD
+++ b/SprintPlan.MD
@@ -48,3 +48,6 @@ This sprint covers foundational tasks for building the initial prototype of LLM-
 - Test suite with passing unit and integration tests
 - Sprint review notes summarizing progress and next steps
 
+
+## Notes
+- Day 1 setup script added at scripts/day1_setup.sh to automate initial environment tasks. Actual kernel build not executed in repository due to environment limitations.

--- a/day1.MD
+++ b/day1.MD
@@ -136,3 +136,6 @@ This schedule expands on the Day 1 task from the sprint plan (see `SprintPlan.MD
 | 15:30-15:45 | Team sync-up and Q&A | QA Agent |
 | 15:45-16:00 | End-of-day wrap-up and next steps | QA Agent |
 
+
+A helper script (`scripts/day1_setup.sh`) automates these DevOps tasks for reproducibility.
+

--- a/scripts/day1_setup.sh
+++ b/scripts/day1_setup.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Day 1 setup script for LLM-RAG-OS
+# This script automates the tasks outlined in day1.MD for the DevOps Agent.
+# Note: Actual hardware checks and long-running kernel build steps may
+# need manual supervision or additional configuration.
+
+set -euo pipefail
+
+# 09:00 - Review hardware requirements
+# Placeholder: ensure at least 16GB RAM and virtualization support
+# (Implementation left for manual check or lshw output parsing)
+
+echo "[09:00] Hardware requirements check - manual verification recommended"
+
+# 09:15 - Boot development machines and verify network
+ping -c 1 github.com >/dev/null && echo "[09:15] Network connectivity OK" || echo "[09:15] Network connectivity FAILED"
+
+# 09:30 - Install missing OS packages and drivers
+# Example for Debian-based systems
+sudo apt-get update && sudo apt-get install -y build-essential git qemu-system-x86
+
+# 09:45 - Set up workspace directories
+mkdir -p ~/workspace && cd ~/workspace
+
+# 10:00 - Clone repository and submodules
+if [ ! -d llm-os ]; then
+  git clone --recurse-submodules https://github.com/bajpainaman/llm-os.git
+fi
+cd llm-os
+
+git checkout llm-rag-os-main
+
+git pull
+
+# 10:45 - Configure kernel build toolchain
+sudo apt-get install -y gcc make libncurses-dev flex bison openssl libssl-dev bc
+
+# 11:00 - Generate default kernel config
+cd llm-rag-os-kernel
+make defconfig
+
+# 11:15 - Start kernel compilation
+make -j$(nproc)
+
+# 11:30 - Monitor build progress for errors
+# (Make command will exit on failure due to set -e)
+
+# 11:45 - Install modules
+sudo make modules_install
+
+# 12:00 - Run basic kernel tests
+make test || true
+
+# 12:15 - Record build results
+cd ..
+mkdir -p build_logs
+journalctl -k > build_logs/kernel_build.log || true
+
+# 12:30 - Launch QEMU for a simple boot test
+qemu-system-x86_64 -kernel llm-rag-os-kernel/arch/x86/boot/bzImage -nographic -append "console=ttyS0" &
+QEMU_PID=$!
+sleep 30
+kill $QEMU_PID
+
+# 12:45 - Mark QEMU boot completed
+
+echo "Day 1 setup completed" > DAY1_STATUS
+


### PR DESCRIPTION
## Summary
- add automation script for DevOps Day 1 tasks
- document quick start in README
- note Day 1 script in SprintPlan
- mention script in Day 1 schedule
- log contribution in Agents guide

## Testing
- `make help` in `llm-rag-os-kernel`
- `make test` (fails: missing `.config`)

------
https://chatgpt.com/codex/tasks/task_e_68544ae0c94c8323a6e58a4e2fe19461