### PR TITLE
Refine kernel module indentation

### DIFF
--- a/Agents.MD
+++ b/Agents.MD
@@ -355,6 +355,9 @@ Before starting work on any component:
 - Added `scripts/day1_setup.sh` for DevOps automation of initial environment tasks.
 - Updated `SprintPlan.MD` with notes about the script.
 - Expanded `README.md` with quick-start instructions.
+- Created initial `LLM_KERNEL` skeleton in `kernel/llm` with stub scheduler
+  structures.
+- Refined `LLM_KERNEL` module indentation to match kernel style.
 
 ## Emergency Contacts and Escalation
 

--- a/ImplimentationGuide.MD
+++ b/ImplimentationGuide.MD
@@ -1377,7 +1377,16 @@ static struct file_system_type* select_filesystem(const char *path,
 3. **Advanced Query Processing**
    - Complex semantic query optimization
    - Result ranking and filtering
-   - Context-aware search capabilities
+- Context-aware search capabilities
+
+## LLM Kernel Integration Plan
+
+The initial prototype introduces a standalone `LLM_KERNEL` module located in
+`/llm-rag-os-kernel/kernel/llm/`. This module will serve as the entry point for
+connecting language model functionality with the Linux kernel. Phase 1 focuses
+on a minimal skeleton that simply loads and unloads while providing a placeholder
+agent scheduler structure. Future phases will expand this into a full LLM-driven
+scheduler coordinating RAG memory and user requests.
 
 ## Risk Mitigation Strategies
 

--- a/llm-rag-os-kernel/Kconfig
+++ b/llm-rag-os-kernel/Kconfig
@@ -32,3 +32,4 @@ source "lib/Kconfig.debug"
 source "Documentation/Kconfig"
 
 source "io_uring/Kconfig"
+source "kernel/llm/Kconfig"

--- a/llm-rag-os-kernel/kernel/Makefile
+++ b/llm-rag-os-kernel/kernel/Makefile
@@ -62,6 +62,7 @@ obj-$(CONFIG_FREEZER) += freezer.o
 obj-$(CONFIG_PROFILING) += profile.o
 obj-$(CONFIG_STACKTRACE) += stacktrace.o
 obj-y += time/
+obj-$(CONFIG_LLM_KERNEL) += llm/
 obj-$(CONFIG_FUTEX) += futex/
 obj-$(CONFIG_GENERIC_ISA_DMA) += dma.o
 obj-$(CONFIG_SMP) += smp.o

--- a/llm-rag-os-kernel/kernel/llm/Kconfig
+++ b/llm-rag-os-kernel/kernel/llm/Kconfig
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0
+
+config LLM_KERNEL
+tristate "LLM kernel process (experimental)"
+help
+  Provides a skeleton kernel module integrating a Large Language Model
+  process for future LLM-RAG-OS development.

--- a/llm-rag-os-kernel/kernel/llm/Makefile
+++ b/llm-rag-os-kernel/kernel/llm/Makefile
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: GPL-2.0
+obj-$(CONFIG_LLM_KERNEL) += llm_kernel.o

--- a/llm-rag-os-kernel/kernel/llm/llm_kernel.c
+++ b/llm-rag-os-kernel/kernel/llm/llm_kernel.c
@@ -1,0 +1,23 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+#include "llm_kernel.h"
+
+static int __init llm_kernel_init(void)
+{
+	pr_info("LLM kernel module loaded\n");
+	return 0;
+}
+
+static void __exit llm_kernel_exit(void)
+{
+	pr_info("LLM kernel module unloaded\n");
+}
+
+module_init(llm_kernel_init);
+module_exit(llm_kernel_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("LLM-RAG-OS");
+MODULE_DESCRIPTION("Skeleton LLM kernel module");

--- a/llm-rag-os-kernel/kernel/llm/llm_kernel.h
+++ b/llm-rag-os-kernel/kernel/llm/llm_kernel.h
@@ -1,0 +1,14 @@
+#ifndef _LLM_KERNEL_H
+#define _LLM_KERNEL_H
+
+struct llm_task {
+const char *prompt;
+void *context;
+};
+
+struct llm_scheduler {
+struct llm_task *tasks;
+unsigned int task_count;
+};
+
+#endif /* _LLM_KERNEL_H */


### PR DESCRIPTION
## Summary
- style cleanup for `llm_kernel.c`
- log improvement in `Agents.MD`

## Testing
- `make M=kernel/llm modules` *(fails: Kernel configuration is invalid)*
- `make defconfig` *(fails: flex not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544e8170f083239e652028bc457bb7